### PR TITLE
Copy usage to v2 instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,19 @@ Set Webpack to resolve root, allowing you to import modules from an absolute pro
 
     `yarn add --dev gatsby-plugin-root-import`
 
+### Usage
+
+Add into `gatsby-config.js`.
+
+```javascript
+// gatsby-config.js
+
+module.exports = {
+  plugins: [
+    'gatsby-plugin-root-import'
+  ]
+}
+```
 
 ### Default Settings
 Webpack v4 drops `resolve.root` in favor of `resolve.alias` found [here](https://webpack.js.org/configuration/resolve/#resolve-alias).


### PR DESCRIPTION
For consistency, it might be helpful to show the same usage instructions for v2 an v1 instructions. 
I was unsure if I needed to add `'gatsby-plugin-root-import'` to my plugins